### PR TITLE
Pin specific commits of 3rd party GitHub actions to ensure predictable version selection

### DIFF
--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install PHP
-        uses: shivammathur/setup-php@2.7.0
+        uses: shivammathur/setup-php@e6f75134d35752277f093989e72e140eaa222f35 # v2.28.0
         with:
           php-version: '7.4'
           coverage: none

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: Create Release
-        uses: technote-space/release-github-actions@v7
+        uses: technote-space/release-github-actions@052f205daf62dff0c3ece009f07b38f3ec83e01a # v8.0.3
         with:
           BUILD_COMMAND_TARGET: 'build'
           CLEAN_TEST_TAG: true


### PR DESCRIPTION
This PR intends to add the security enhancement of pinning specific SHA1 commits for 3rd-party Github actions.