### PR TITLE
Adjust imports to fix deprecation errors

### DIFF
--- a/src/plugins/editorial-comment-list-sidebar/index.js
+++ b/src/plugins/editorial-comment-list-sidebar/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { PluginSidebar } from '@wordpress/edit-post';
+import { PluginSidebar } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 import { name as editorialCommentBlock } from '../../blocks/editorial-comment';

--- a/src/plugins/editorial-comment-list-sidebar/index.js
+++ b/src/plugins/editorial-comment-list-sidebar/index.js
@@ -35,7 +35,7 @@ const findNestedCommentBlocks = ( memo, block ) => {
 const EditorialCommentListSidebar = () => {
 	const { selectBlock } = useDispatch( 'core/editor' );
 	const comments = useSelect( ( select ) => {
-		return select( 'core/editor' ).getBlocks().reduce( findNestedCommentBlocks, [] );
+		return select( 'core/block-editor' ).getBlocks().reduce( findNestedCommentBlocks, [] );
 	} );
 
 	return (


### PR DESCRIPTION
Adjust where we import the `getBlocks` selector and `PluginSidebar` component from, in order to resolve deprecation warnings when using this plugin.

Fixes #1